### PR TITLE
chore: pin trivy-actions version

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -57,7 +57,7 @@ jobs:
           provenance: false
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ghcr.io/${{ github.repository }}:latest-thick
           ignore-unfixed: true


### PR DESCRIPTION
chore: pin trivy-actions version `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`